### PR TITLE
when the orig channel ends end ext media channel

### DIFF
--- a/lib/Bridge.js
+++ b/lib/Bridge.js
@@ -35,13 +35,16 @@ class Bridge extends EventEmitter {
         let externalMediaUdpSourcePort = null;
         let callerName = channel.caller.name || 'Unknown';
 
+        channel.once('StasisEnd', async () => {
+            await externalMediaChannel.hangup();
+        });
 
-        externalMediaChannel.on('StasisStart', (event, channel) => {
+        externalMediaChannel.once('StasisStart', (event, channel) => {
             this.logger.info(event, 'got a stasisStart event on the externalMediaChannel');
             this.bridge.addChannel({channel: channel.id});
         });
 
-        externalMediaChannel.on('StasisEnd', () => {
+        externalMediaChannel.once('StasisEnd', () => {
             this.logger.info('external media channel ended');
             this.emit('streamEnded', {
                 roomName: channel.dialplan.exten,


### PR DESCRIPTION
untested, should work hopefully
code was copied from a proper bridge in ARI with multiple
participants. This is a one on one call so we can say
when the original channel ends, end the external media
channel which will then cause the bridge to be destroyed

closes #1 