### PR TITLE
Add optional media playback before bridge

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -10,6 +10,11 @@ module.exports = {
         port: '7777',
         format: 'slin16'
     },
+    asterisk: {
+        // If set then Playback this Asterisk sound file before bridging to the dialogflow media.
+        // Useful for debug and breaking media stand-offs.
+        // playback: 'silence/1'
+    },
     mqtt: {
         url: 'mqtt://test.mosquitto.org',
         topicPrefix: 'dialogflow-asterisk'

--- a/index.js
+++ b/index.js
@@ -47,6 +47,13 @@ async function main() {
             let logger = log.child({id: channel.id});
             logger.info({event}, 'channel entered our application');
 
+            if(config.has('asterisk.playback')){
+                let playback = client.Playback();
+                let playbackFinished = new Promise (resolve => playback.once('PlaybackFinished', resolve));
+                channel.play({ media:`sound:${config.get('asterisk.playback')}` }, playback);
+                await playbackFinished;
+            }
+
             let bridge = new Bridge(client, log);
 
             channels.set(channel.id, bridge);


### PR DESCRIPTION
Hack to force an Asterisk media playback before executing the bridge to the audioserver media. Useful for debug (test Asterisk media before blaming audioserver networking setup), but also good for eliminating possible media stand-offs by using e.g. silence/1.